### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ If your import is an extract of the planet and has polygonal bounds associated w
 ```
 docker run \
     -e UPDATES=enabled \
+    -e REPLICATION_URL=https://planet.openstreetmap.org/replication/minute/ \
+    -e MAX_INTERVAL_SECONDS=60 \
     -v /absolute/path/to/luxembourg.osm.pbf:/data/region.osm.pbf \
     -v /absolute/path/to/luxembourg.poly:/data/region.poly \
     -v osm-data:/data/database/ \
@@ -126,8 +128,6 @@ Given that you've set up your import as described in the *Automatic updates* sec
 ```
 docker run \
     -p 8080:80 \
-    -e REPLICATION_URL=https://planet.openstreetmap.org/replication/minute/ \
-    -e MAX_INTERVAL_SECONDS=60 \
     -e UPDATES=enabled \
     -v osm-data:/data/database/ \
     -v osm-tiles:/data/tiles/ \


### PR DESCRIPTION
### Fix: Move `REPLICATION_URL` and `MAX_INTERVAL_SECONDS` to the correct part of the Docker command

In the original Docker command, the environment variables `REPLICATION_URL` and `MAX_INTERVAL_SECONDS` were incorrectly placed in the `run` command. These variables are intended to be used during the import process, not during the `run` command.

This update moves the variables to the appropriate section of the command to ensure proper functionality during data import, where these variables are needed for configuring replication settings.

#### Changes:
- Moved `REPLICATION_URL` and `MAX_INTERVAL_SECONDS` from the `run` command to the `import` command.

Now, the Docker command is correctly configured to import data with replication settings.
